### PR TITLE
Update SCMCMouseListener.m

### DIFF
--- a/Sculpt Control Inject Bundle/Sculpt Control Inject Bundle/SCMCMouseListener.m
+++ b/Sculpt Control Inject Bundle/Sculpt Control Inject Bundle/SCMCMouseListener.m
@@ -11,9 +11,9 @@
 @import IOKit.hid;
 
 typedef NS_ENUM(uint32_t, ButtonCode) {
-    ButtonCodeClick = 64817,
-    ButtonCodeSwipeUp = 64809,
-    ButtonCodeSwipeDown = 64816,
+    ButtonCodeClick = 227,
+    ButtonCodeSwipeUp = 42,
+    ButtonCodeSwipeDown = 43,
 };
 
 typedef NS_ENUM(NSInteger, LongClickState) {


### PR DESCRIPTION
This fixes your app for my Microsoft Sculpt Comfort Mouse on OS X 10.10.4. Perhaps, there are some slightly different models with slightly different drivers for them?
