### PR TITLE
update configuration of scuplt comfort for macOS10.13

### DIFF
--- a/Configuration/sculpt comfort 3.plist
+++ b/Configuration/sculpt comfort 3.plist
@@ -5,9 +5,9 @@
 	<key>scmc</key>
 	<dict>
 		<key>product-id</key>
-		<integer>1954</integer>
+		<integer>0x7a2</integer>
 		<key>vendor-id</key>
-		<integer>1118</integer>
+		<integer>0x45e</integer>
 		<key>click-code</key>
 		<integer>227</integer>
 		<key>swipe-up-code</key>

--- a/Configuration/sculpt comfort 3.plist
+++ b/Configuration/sculpt comfort 3.plist
@@ -8,12 +8,14 @@
 		<integer>0x7a2</integer>
 		<key>vendor-id</key>
 		<integer>0x45e</integer>
+
 		<key>click-code</key>
 		<integer>227</integer>
 		<key>swipe-up-code</key>
 		<integer>5</integer>
 		<key>swipe-down-code</key>
 		<integer>4</integer>
+
 		<key>click-action</key>
 		<string>mission-control</string>
 		<key>long-click-action</key>

--- a/Configuration/sculpt comfort macOS10.13.plist
+++ b/Configuration/sculpt comfort macOS10.13.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>scmc</key>
+	<dict>
+		<key>product-id</key>
+		<integer>1954</integer>
+		<key>vendor-id</key>
+		<integer>1118</integer>
+		<key>click-code</key>
+		<integer>227</integer>
+		<key>swipe-up-code</key>
+		<integer>5</integer>
+		<key>swipe-down-code</key>
+		<integer>4</integer>
+		<key>click-action</key>
+		<string>mission-control</string>
+		<key>long-click-action</key>
+		<string>application-windows</string>
+		<key>swipe-up-action</key>
+		<string>previous-space</string>
+		<key>swipe-down-action</key>
+		<string>next-space</string>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
With debug, get **swipe-up-code** is *5* and **swipe-down-code** is *4* in macOS 10.13